### PR TITLE
fixed "rbg" typo in example JSON dictionary

### DIFF
--- a/src/Example/Dictionary.JSON
+++ b/src/Example/Dictionary.JSON
@@ -9,7 +9,7 @@
     {
       "Language": "Dutch",
       "Font": "Arial",
-      "Color": "rbg(55,55,55)"
+      "Color": "rgb(55,55,55)"
     },
     {
       "Language": "Chinese",


### PR DESCRIPTION
fixes #31 